### PR TITLE
backport from mlpack 3.3.0; handle SpSubview_col and SpSubview_row in Armadillo 9.870

### DIFF
--- a/src/mlpack/core/util/arma_traits.hpp
+++ b/src/mlpack/core/util/arma_traits.hpp
@@ -91,14 +91,33 @@ struct IsVector<arma::subview_row<eT> >
   const static bool value = true;
 };
 
-// I'm not so sure about this one.  An SpSubview object can be a row or column,
-// but it can also be a matrix subview.
+#if ((ARMA_VERSION_MAJOR >= 10) || \
+    ((ARMA_VERSION_MAJOR == 9) && (ARMA_VERSION_MINOR >= 869)))
 
-//template<>
-template<typename eT>
-struct IsVector<arma::SpSubview<eT> >
-{
-  const static bool value = true;
-};
+  // Armadillo 9.869+ has SpSubview_col and SpSubview_row
+
+  template<typename eT>
+  struct IsVector<arma::SpSubview_col<eT> >
+  {
+    const static bool value = true;
+  };
+
+  template<typename eT>
+  struct IsVector<arma::SpSubview_row<eT> >
+  {
+    const static bool value = true;
+  };
+
+#else
+
+  // fallback for older Armadillo versions
+
+  template<typename eT>
+  struct IsVector<arma::SpSubview<eT> >
+  {
+    const static bool value = true;
+  };
+
+#endif
 
 #endif


### PR DESCRIPTION
Backport from mlpack 3.3.0. This is so the old RcppMLPACK package doesn't break when RcppArmadillo is upgraded to Armadillo 9.870.

RcppMLPACK on CRAN: https://cran.r-project.org/web/packages/RcppMLPACK/index.html

Related to https://github.com/mlpack/mlpack/pull/2356

cc: @eddelbuettel @rcurtin @thirdwing 

